### PR TITLE
Add calendar placeholder widget

### DIFF
--- a/lib/features/dashboard/dashboard_screen.dart
+++ b/lib/features/dashboard/dashboard_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../modules/calendar/calendar_screen.dart';
 
 class DashboardScreen extends StatelessWidget {
   const DashboardScreen({super.key});
@@ -9,10 +10,26 @@ class DashboardScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Family Hub'),
       ),
-      body: const Center(
-        child: Text(
-          'Dashboard Placeholder',
-          style: TextStyle(fontSize: 24),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'Dashboard Placeholder',
+              style: TextStyle(fontSize: 24),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => const CalendarScreen(),
+                  ),
+                );
+              },
+              child: const Text('Open Calendar'),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/modules/calendar/calendar_screen.dart
+++ b/lib/modules/calendar/calendar_screen.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class CalendarScreen extends StatelessWidget {
+  const CalendarScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    const events = [
+      'Birthday Party',
+      'Doctor Appointment',
+      'Family Dinner',
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Calendar'),
+      ),
+      body: ListView.builder(
+        itemCount: events.length,
+        itemBuilder: (context, index) {
+          return ListTile(
+            leading: const Icon(Icons.event),
+            title: Text(events[index]),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:family_hub/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('Dashboard screen loads', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const FamilyHubApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the dashboard placeholder text is shown.
+    expect(find.text('Dashboard Placeholder'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add new `CalendarScreen` in `lib/modules/calendar`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca67e0fcc8329844df2edd46bc9aa